### PR TITLE
Fix token payload to include username

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -122,7 +122,12 @@ app.post("/login", async (req, res) => {
             return res.status(401).json({ message: "Invalid username/email or password." });
         }
 
-        const token = jwt.sign({ id: user.id, email: user.email }, SECRET_KEY, { expiresIn: "1h" });
+        // Include username in the token payload so it is available when verifying
+        const token = jwt.sign(
+            { id: user.id, username: user.username, email: user.email },
+            SECRET_KEY,
+            { expiresIn: "1h" }
+        );
         res.json({ token, user: { id: user.id, username: user.username, email: user.email } });
     } catch (err) {
         console.error("Login error:", err);


### PR DESCRIPTION
## Summary
- include username in JWT payload so `/verify-token` returns username as expected

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*
- `npm test --prefix backend --silent` *(no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_6846eb716490832f8c8bb9e23823a29e